### PR TITLE
Message shows only 768px wide, when on iPad in landscape mode.

### DIFF
--- a/Classes/TSMessage.h
+++ b/Classes/TSMessage.h
@@ -22,6 +22,7 @@ typedef enum {
 
 @property (nonatomic, strong) NSMutableArray *messages;
 
+@property (strong, nonatomic) UIViewController *viewController;
 
 + (TSMessage *)sharedNotification;
 

--- a/Classes/TSMessage.m
+++ b/Classes/TSMessage.m
@@ -14,8 +14,6 @@
 
 @interface TSMessage ()
 
-@property (strong, nonatomic) UIViewController *viewController;
-
 - (void)fadeInCurrentNotification;
 - (void)fadeOutCurrentNotification;
 - (void)startFadingOutWithDelay:(NSNumber *)delay;

--- a/Views/TSMessageView.m
+++ b/Views/TSMessageView.m
@@ -28,10 +28,7 @@ static NSDictionary *notificationDesign;
                                                                error:nil];
     }
     
-    if (!screenWidth)
-    {
-        screenWidth = [UIScreen mainScreen].bounds.size.width;
-    }
+    screenWidth = [[[TSMessage sharedNotification] viewController] view].frame.size.width;
     
     if ((self = [self init]))
     {


### PR DESCRIPTION
Message shows only 768px wide, when on iPad in landscape mode. (This fixes the initial message, it doesn't fix rotation while a message is showing)
