### PR TITLE
Fixed notification comparasion when title or content is nil value.

### DIFF
--- a/Classes/TSMessage.m
+++ b/Classes/TSMessage.m
@@ -130,7 +130,7 @@ static BOOL notificationActive;
 {
     for (TSMessageView *n in [TSMessage sharedMessage].messages)
     {
-        if (([n.title isEqualToString:title] || (!n.title && !title)) && ([n.content isEqualToString:message] || (!n.content && !content)))
+        if (([n.title isEqualToString:title] || (!n.title && !title)) && ([n.content isEqualToString:message] || (!n.content && !message)))
         {
             return; // avoid showing the same messages twice in a row
         }


### PR DESCRIPTION
When comparing two notifications, if both title strings or both content strings are nil values, notifications should be equal. 

In Objective-C two nils are not equal, but in this situation, I think it is more semantically correct to assume that nil string are equal.
