### PR TITLE
Added UITabBarController check, with additional check to see if status bar is shown.

### DIFF
--- a/Classes/TSMessage.m
+++ b/Classes/TSMessage.m
@@ -223,6 +223,14 @@ static BOOL notificationActive;
             [currentView.viewController.view addSubview:currentView];
         }
     }
+    else if ([currentView.viewController isKindOfClass:[UITabBarController class]])
+    {
+        if (![UIApplication sharedApplication].statusBarHidden) {
+            verticalOffset += 20.0f;
+        }
+        
+        [currentView.viewController.view addSubview:currentView];
+    }
     else
     {
         [currentView.viewController.view addSubview:currentView];


### PR DESCRIPTION
If you have a `UITabBarController` as your apps initial view controller, then the message view is positioned wrong. Added UITabBarController check, with additional check to see if status bar is shown.
