### PR TITLE
add gesture recognizer delegate method to fix issue #40

### DIFF
--- a/Views/TSMessageView.m
+++ b/Views/TSMessageView.m
@@ -275,10 +275,12 @@ static NSMutableDictionary *_notificationDesign;
             [gestureRec setDirection:(self.messagePosition == TSMessageNotificationPositionTop ?
                                       UISwipeGestureRecognizerDirectionUp :
                                       UISwipeGestureRecognizerDirectionDown)];
+            gestureRec.delegate = self;
             [self addGestureRecognizer:gestureRec];
             
             UITapGestureRecognizer *tapRec = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                      action:@selector(fadeMeOut)];
+            tapRec.delegate = self;
             [self addGestureRecognizer:tapRec];
         }
     }
@@ -396,6 +398,13 @@ static NSMutableDictionary *_notificationDesign;
     }
     
     [self fadeMeOut];
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    return ! ([touch.view isKindOfClass:[UIControl class]]);
 }
 
 @end


### PR DESCRIPTION
Discussions on this issue 

http://stackoverflow.com/questions/13515539/uibutton-not-works-in-ios-5-x-everything-is-fine-in-ios-6-x

Fixed by adding a delegate method.
