### PR TITLE
NS_ENUM

### DIFF
--- a/Classes/TSMessage.h
+++ b/Classes/TSMessage.h
@@ -167,10 +167,8 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
 /** Shows a predefined error message, that is displayed, when this action requires location services */
 + (void)showLocationError;
 
-
-
-
-/** Implement this in subclass to set a default view controller */
++ (void)setDefaultViewController:(UIViewController *)defaultViewController;
+/** You can also override this in subclass instead of using setDefaultViewController */
 + (UIViewController *)defaultViewController;
 
 @end

--- a/Classes/TSMessage.m
+++ b/Classes/TSMessage.m
@@ -28,6 +28,7 @@
 static TSMessage *sharedMessages;
 static BOOL notificationActive;
 
+__weak static UIViewController *_defaultViewController;
 
 + (TSMessage *)sharedMessage
 {
@@ -136,6 +137,7 @@ static BOOL notificationActive;
                      canBeDismisedByUser:(BOOL)dismissingEnabled
 {
     // Create the TSMessageView
+    if(!viewController) viewController = [self defaultViewController];
     TSMessageView *v = [[TSMessageView alloc] initWithTitle:title
                                                 withContent:message
                                                    withType:type
@@ -337,9 +339,14 @@ static BOOL notificationActive;
 
 + (UIViewController *)defaultViewController
 {
-    NSLog(@"No view controller was set as parameter and TSMessage was not subclassed. If you want to subclass, implement defaultViewController to set the default viewController.");
-    return nil;
-    // Implement this in subclass
+    if(!_defaultViewController) {
+        NSLog(@"Attempted to present TSMessage in default view controller, but no default view controller was set. Use +[TSMessage setDefaultViewController:] or subclass TSMessage.");
+    }
+    return _defaultViewController;
 }
 
++ (void)setDefaultViewController:(UIViewController *)defaultViewController
+{
+    _defaultViewController = defaultViewController;
+}
 @end


### PR DESCRIPTION
The preferred way to do type enumerations is now with NS_ENUM. I've incorporated it into the header. I don't know all the benefits of using it, but the major one to me is that autocomplete only shows completions that match the target type and that LLDB prints the enumerated name rather than the integer value.

If you remove the #ifndef block, then this will only build on iOS SDK 6 or later. Enjoy!
