### PR TITLE
Use NS_ENUM rather than enum

### DIFF
--- a/Classes/TSMessage.h
+++ b/Classes/TSMessage.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 // NS_ENUM is now the preferred way to do typedefs. It gives the compiler and debugger more information, which helps everyone.
-// When using SDK 6.1 or later, NS_ENUM is defined by Apple, so this block does nothing.
+// When using SDK 6 or later, NS_ENUM is defined by Apple, so this block does nothing.
 // For SDK 5 or earlier, this is the same definition block Apple uses.
 #ifndef NS_ENUM
 #if (__cplusplus && __cplusplus >= 201103L && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum))) || (!__cplusplus && __has_feature(objc_fixed_enum))


### PR DESCRIPTION
NS_ENUM is now the preferred way to enumerate types – it hints LLDB and the compiler, so that (for example) switch statements can be checked for coverage, printed enumerated types can use names rather than integers, etc.

Remove the defines at the top once you're ready to require iOS SDK 6 
