### PR TITLE
dismiss endless messages when the view controller is dismissed

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -438,6 +438,13 @@ static NSMutableDictionary *_notificationDesign;
     [[TSMessage sharedMessage] performSelectorOnMainThread:@selector(fadeOutNotification:) withObject:self waitUntilDone:NO];
 }
 
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (self.duration == TSMessageNotificationDurationEndless && self.superview && !self.window ) {
+        // view controller was dismissed, let's fade out
+        [self fadeMeOut];
+    }
+}
 #pragma mark - Target/Action
 
 - (void)buttonTapped:(id) sender


### PR DESCRIPTION
When a message endless message was shown in a view controller inside a navigation view controller an the vc is popped , the message isn't visible but still in the message queue.

Another solution would be a method which allows to remove all messages in a specific view controller.
This way the view controller could remove all it's messages in - viewDidDisappear.
