### PR TITLE
Add an iOS 7 style check when setting the vertical offset for notification inside UINavigtationControllers.

### DIFF
--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -172,7 +172,9 @@ __weak static UIViewController *_defaultViewController;
             [currentView.viewController.view insertSubview:currentView
                                               belowSubview:[(UINavigationController *)currentView.viewController navigationBar]];
             verticalOffset = [(UINavigationController *)currentView.viewController navigationBar].bounds.size.height;
-            addStatusBarHeightToVerticalOffset();
+            if ([TSMessage iOS7StyleEnabled]) {
+                addStatusBarHeightToVerticalOffset();
+            }
         }
         else
         {


### PR DESCRIPTION
Looks like most of this was fixed with #61 but in my case I'm adding notifications to a UINavigationController and the offset is not being calculated properly on iOS 6
