### PR TITLE
[Bugfix] in iOS 7 the notifications slipped under the UINavigationBar. I...

### DIFF
--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -165,13 +165,21 @@ __weak static UIViewController *_defaultViewController;
         verticalOffset += offset;
     };
     
-    if ([currentView.viewController isKindOfClass:[UINavigationController class]])
+    if ([currentView.viewController isKindOfClass:[UINavigationController class]] || [currentView.viewController.parentViewController isKindOfClass:[UINavigationController class]])
     {
-        if (![(UINavigationController *)currentView.viewController isNavigationBarHidden])
+        UINavigationController *currentNavigationController;
+        
+        if([currentView.viewController isKindOfClass:[UINavigationController class]])
+            currentNavigationController = (UINavigationController *)currentView.viewController;
+        else
+            currentNavigationController = (UINavigationController *)currentView.viewController.parentViewController;
+            
+        
+        if (![currentNavigationController isNavigationBarHidden])
         {
-            [currentView.viewController.view insertSubview:currentView
-                                              belowSubview:[(UINavigationController *)currentView.viewController navigationBar]];
-            verticalOffset = [(UINavigationController *)currentView.viewController navigationBar].bounds.size.height;
+            [currentNavigationController.view insertSubview:currentView
+                                              belowSubview:[currentNavigationController navigationBar]];
+            verticalOffset = [currentNavigationController navigationBar].bounds.size.height;
             if ([TSMessage iOS7StyleEnabled]) {
                 addStatusBarHeightToVerticalOffset();
             }


### PR DESCRIPTION
... fixed this issue here.

but what exactly is `[currentView.viewController isKindOfClass:[UINavigationController class]]` doing here? This only happens when i am adding it directly to a UINavigationController. 

Now you can push it to a ViewController and it will be checked if the ViewController has an UINavigationController parent.
