### PR TITLE
Fix compile error using iOS SDKs before iOS 7

### DIFF
--- a/TSMessages/Views/TSBlurView.m
+++ b/TSMessages/Views/TSBlurView.m
@@ -24,7 +24,9 @@
         _toolbar = [[UIToolbar alloc] initWithFrame:self.bounds];
         _toolbar.userInteractionEnabled = NO;
         _toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
         [_toolbar setBackgroundImage:nil forToolbarPosition:UIBarPositionAny barMetrics:UIBarMetricsDefault]; // remove background set through the appearence proxy
+#endif
         [self addSubview:_toolbar];
     }
 


### PR DESCRIPTION
Add  #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000 guard to fix compile error using iOS SDKs before iOS 7
