### PR TITLE
This is a fix for the code that removes the undercut when the navbar is translucent.

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -416,6 +416,9 @@ static NSMutableDictionary *_notificationDesign;
             float topOffset = 0.f;
 
             UINavigationController *navigationController = self.viewController.navigationController;
+            if (!navigationController && [self.viewController isKindOfClass:[UINavigationController class]]) {
+                navigationController = (UINavigationController *)self.viewController;
+            }
             BOOL isNavBarIsHidden = !navigationController || self.viewController.navigationController.navigationBarHidden;
             BOOL isNavBarIsOpaque = !self.viewController.navigationController.navigationBar.isTranslucent && self.viewController.navigationController.navigationBar.alpha == 1;
             


### PR DESCRIPTION
If the current view controller is a navigation controller then it will not have its own navigation controller.
