### PR TITLE
DefaultViewController is globally available

### DIFF
--- a/TSMessages/Classes/TSMessage.h
+++ b/TSMessages/Classes/TSMessage.h
@@ -53,6 +53,8 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
 
 + (instancetype)sharedMessage;
 
++ (UIViewController *)defaultViewController;
+
 /** Shows a notification message
  @param message The title of the notification view
  @param type The notification type (Message, Warning, Error, Success)

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -20,9 +20,6 @@
 /** The queued messages (TSMessageView objects) */
 @property (nonatomic, strong) NSMutableArray *messages;
 
-+ (UIViewController *)defaultViewController;
-
-
 - (void)fadeInCurrentNotification;
 - (void)fadeOutNotification:(TSMessageView *)currentView;
 


### PR DESCRIPTION
Hi all,

Small change here. I think having the defaultViewController a class method available everywhere is more useful. 

In my case I need this because to use the detailed showNotification method asks for the view controller which I already set the default one and I don't know it at the showNotification time.

Thanks for the awesome control!
ton.
