### PR TITLE
fix a crash problem

### DIFF
--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -312,6 +312,7 @@ __weak static UIViewController *_defaultViewController;
     
     dispatch_async(dispatch_get_main_queue(), ^
                    {
+                       if ([[TSMessage sharedMessage].messages count] == 0) return;
                        TSMessageView *currentMessage = [[TSMessage sharedMessage].messages objectAtIndex:0];
                        if (currentMessage.messageIsFullyDisplayed)
                        {


### PR DESCRIPTION
If "dismissActiveNotification" method is running in background thread, "objectAtIndex:0" will crash if the array become empty after checking.
