### PR TITLE
Make a message tappable even though it is not dismissible

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -325,11 +325,11 @@ static NSMutableDictionary *_notificationDesign;
             UITapGestureRecognizer *tapRec = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                      action:@selector(fadeMeOut)];
             [self addGestureRecognizer:tapRec];
-
-            UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
-            tapGesture.delegate = self;
-            [self addGestureRecognizer:tapGesture];
         }
+        
+        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+        tapGesture.delegate = self;
+        [self addGestureRecognizer:tapGesture];
     }
     return self;
 }
@@ -480,8 +480,6 @@ static NSMutableDictionary *_notificationDesign;
         {
             self.callback();
         }
-
-        [self fadeMeOut];
     }
 }
 


### PR DESCRIPTION
- change handleTap so it does not automatically cause fadeMeOut
- always add UITapGestureRecognizer, not only if dismissAble

These changes allow a tap to be handled even though the message is not dismissible. This is useful if you want to perform some operation based on the tap, but only (programmatically) remove the message if the operation completed successfully.

Note that previously, fadeMeOut was called by both the handleTap code and a separate TapGestureRecognizer. The changes in this pull request separate the dismissal logic from the callback. It adds functionality; with these changes you can still choose not to specify a callback. One other thing to consider is that previously specifying a callback only had effect if the message was dismissAble, so it's possible that previously (uselessly) specified callbacks on un-dismissAble messages will now become accessible via tap.

PS Thank you for this great library! I hope you will consider merging these changes.
Best regards,
Steven
