### PR TITLE
Fix message offset for nested controllers

### DIFF
--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -172,7 +172,7 @@ __weak static UIViewController *_defaultViewController;
             currentNavigationController = (UINavigationController *)currentView.viewController.parentViewController;
             
         BOOL isViewIsUnderStatusBar = [[[currentNavigationController childViewControllers] firstObject] wantsFullScreenLayout];
-        if (!isViewIsUnderStatusBar) {
+        if (!isViewIsUnderStatusBar && currentNavigationController.parentViewController == nil) {
             isViewIsUnderStatusBar = ![currentNavigationController isNavigationBarHidden]; // strange but true
         }
         if (![currentNavigationController isNavigationBarHidden])


### PR DESCRIPTION
This fixes the message offset when building with iOS 6 SDK and using nested controllers, e.g. a `UISplitViewController` and displaying the message on one of its children.
