### PR TITLE
Improve callbacks by passing the view as a parameter

### DIFF
--- a/ExampleProject/Example/TSDemoViewController.m
+++ b/ExampleProject/Example/TSDemoViewController.m
@@ -60,7 +60,7 @@
                                        duration:TSMessageNotificationDurationAutomatic
                                        callback:nil
                                     buttonTitle:NSLocalizedString(@"Update", nil)
-                                 buttonCallback:^{
+                                 buttonCallback:^(TSMessageView *messageView){
                                      [TSMessage showNotificationWithTitle:NSLocalizedString(@"Thanks for updating", nil)
                                                                      type:TSMessageNotificationTypeSuccess];
                                  }

--- a/TSMessages/Classes/TSMessage.h
+++ b/TSMessages/Classes/TSMessage.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
     TSMessageNotificationDurationEndless = -1 // The notification is displayed until the user dismissed it or it is dismissed by calling dismissActiveNotification
 };
 
+typedef void (^TSMessageCallback)(TSMessageView *messageView);
 
 @interface TSMessage : NSObject
 
@@ -102,9 +103,9 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
                                    image:(UIImage *)image
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
-                                callback:(void (^)())callback
+                                callback:(TSMessageCallback)callback
                              buttonTitle:(NSString *)buttonTitle
-                          buttonCallback:(void (^)())buttonCallback
+                          buttonCallback:(TSMessageCallback)buttonCallback
                               atPosition:(TSMessageNotificationPosition)messagePosition
                      canBeDismisedByUser:(BOOL)dismissingEnabled;
 

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -90,9 +90,9 @@ __weak static UIViewController *_defaultViewController;
                                    image:(UIImage *)image
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
-                                callback:(void (^)())callback
+                                callback:(TSMessageCallback)callback
                              buttonTitle:(NSString *)buttonTitle
-                          buttonCallback:(void (^)())buttonCallback
+                          buttonCallback:(TSMessageCallback)buttonCallback
                               atPosition:(TSMessageNotificationPosition)messagePosition
                      canBeDismisedByUser:(BOOL)dismissingEnabled
 {

--- a/TSMessages/Views/TSMessageView.h
+++ b/TSMessages/Views/TSMessageView.h
@@ -64,9 +64,9 @@
                type:(TSMessageNotificationType)notificationType
            duration:(CGFloat)duration
    inViewController:(UIViewController *)viewController
-           callback:(void (^)())callback
+           callback:(TSMessageCallback)callback
         buttonTitle:(NSString *)buttonTitle
-     buttonCallback:(void (^)())buttonCallback
+     buttonCallback:(TSMessageCallback)buttonCallback
          atPosition:(TSMessageNotificationPosition)position
   shouldBeDismissed:(BOOL)dismissAble;
 

--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -50,8 +50,8 @@ static NSMutableDictionary *_notificationDesign;
 @property (nonatomic, assign) CGFloat textSpaceLeft;
 @property (nonatomic, assign) CGFloat textSpaceRight;
 
-@property (copy) void (^callback)();
-@property (copy) void (^buttonCallback)();
+@property (copy) TSMessageCallback callback;
+@property (copy) TSMessageCallback buttonCallback;
 
 - (CGFloat)updateHeightOfMessageView;
 - (void)layoutSubviews;
@@ -91,9 +91,9 @@ static NSMutableDictionary *_notificationDesign;
                type:(TSMessageNotificationType)notificationType
            duration:(CGFloat)duration
    inViewController:(UIViewController *)viewController
-           callback:(void (^)())callback
+           callback:(TSMessageCallback)callback
         buttonTitle:(NSString *)buttonTitle
-     buttonCallback:(void (^)())buttonCallback
+     buttonCallback:(TSMessageCallback)buttonCallback
          atPosition:(TSMessageNotificationPosition)position
   shouldBeDismissed:(BOOL)dismissAble
 {
@@ -466,7 +466,7 @@ static NSMutableDictionary *_notificationDesign;
 {
     if (self.buttonCallback)
     {
-        self.buttonCallback();
+        self.buttonCallback(self);
     }
     
     [self fadeMeOut];
@@ -478,7 +478,7 @@ static NSMutableDictionary *_notificationDesign;
     {
         if (self.callback)
         {
-            self.callback();
+            self.callback(self);
         }
     }
 }


### PR DESCRIPTION
This way one can directly call the `fadeMeOut` method on the actual view instead of having to call `[TSMessage dismissActiveNotification]` (which would be necessary if you want to dismiss the view programmatically in the callback, because you have disabled manual dismiss via `canBeDismissedByUser:NO`).

I find it better to deal with the actual instance of the view rather than relying on it being the currently active notification.

Right now it is only possible for it being the currently active notification, but these changes will make sense in conjunction with the next changes I'd like to propose in the next commits. ;)
