### PR TITLE
Add parameter forceDismiss to dismissActiveNotification method

### DIFF
--- a/TSMessages/Classes/TSMessage.h
+++ b/TSMessages/Classes/TSMessage.h
@@ -115,6 +115,14 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
  */
 + (BOOL)dismissActiveNotification;
 
+/** Fades out the currently displayed notification. If another notification is in the queue,
+ the next one will be displayed automatically
+ @param forceDismiss Should the message be dismissed even if it is not fully displayed
+ @return YES if the currently displayed notification was successfully dismissed. NO if no notification
+ was currently displayed.
+ */
++ (BOOL)dismissActiveNotification:(BOOL)forceDismiss;
+
 /** Use this method to set a default view controller to display the messages in */
 + (void)setDefaultViewController:(UIViewController *)defaultViewController;
 

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -306,7 +306,7 @@ __weak static UIViewController *_defaultViewController;
      }];
 }
 
-+ (BOOL)dismissActiveNotification
++ (BOOL)dismissActiveNotification:(BOOL)forceDismiss
 {
     if ([[TSMessage sharedMessage].messages count] == 0) return NO;
     
@@ -314,12 +314,17 @@ __weak static UIViewController *_defaultViewController;
                    {
                        if ([[TSMessage sharedMessage].messages count] == 0) return;
                        TSMessageView *currentMessage = [[TSMessage sharedMessage].messages objectAtIndex:0];
-                       if (currentMessage.messageIsFullyDisplayed)
+                       if (forceDismiss || currentMessage.messageIsFullyDisplayed)
                        {
                            [[TSMessage sharedMessage] fadeOutNotification:currentMessage];
                        }
                    });
     return YES;
+}
+
++ (BOOL)dismissActiveNotification
+{
+    return [TSMessage dismissActiveNotification: NO];
 }
 
 #pragma mark Customizing TSMessages


### PR DESCRIPTION
Add `+ (BOOL)dismissActiveNotification:(BOOL)forceDismiss` method in order to dismiss the message even if it is not fully displayed.

Here is the use case.

We first display a message showing that we are loading data, and then data comes before the animation has finished. At this moment, we want to force it to dismiss the loading message even if it is not fully displayed. 
