### PR TITLE
Bugfix: Tapping of TSMessageView doesn't dismiss it

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -327,9 +327,11 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             [self addGestureRecognizer:tapRec];
         }
         
-        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
-        tapGesture.delegate = self;
-        [self addGestureRecognizer:tapGesture];
+        if (self.callback) {
+            UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+            tapGesture.delegate = self;
+            [self addGestureRecognizer:tapGesture];
+        }
     }
     return self;
 }


### PR DESCRIPTION
Cause: Two tap gesture recognzier is added to the view which cancels the previous one
