### PR TITLE
fix an issue where the text padding is wrong when no image is used

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -171,7 +171,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
                                                    alpha:1.0];
         
         
-        self.textSpaceLeft = 2 * TSMessageViewPadding;
+        self.textSpaceLeft = TSMessageViewPadding;
         if (image) self.textSpaceLeft += image.size.width + 2 * TSMessageViewPadding;
         
         // Set up title label


### PR DESCRIPTION
When no image is used, the left text padding was set to 2 * the padding.