### PR TITLE
the border is shown on iOS7 if there is a border height set

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -281,7 +281,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         }
         
         // Add a border on the bottom (or on the top, depending on the view's postion)
-        if (![TSMessage iOS7StyleEnabled])
+        if ([[current valueForKey:@"borderHeight"] floatValue])
         {
             _borderView = [[UIView alloc] initWithFrame:CGRectMake(0.0,
                                                                    0.0, // will be set later


### PR DESCRIPTION
I don't know if someone explicitly wants the other behaviour, but I find it odd, that you can explicitly add a `borderHeight` in the configuration file which then is ignored if you are running on iOS7 - feel free to merge or delete...