### PR TITLE
Callback is now called when the message view is dismissed.

### DIFF
--- a/ExampleProject/Example.xcworkspace/xcshareddata/Example.xccheckout
+++ b/ExampleProject/Example.xcworkspace/xcshareddata/Example.xccheckout
@@ -5,34 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>F6FF7C22-1562-4A01-9CD1-A3C34B7E21C3</string>
+	<string>F5457609-387E-4BAC-A3E1-DE061D0E133A</string>
 	<key>IDESourceControlProjectName</key>
 	<string>Example</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>56C72571-8325-46B6-BC46-920E7DE5B629</key>
-		<string>https://github.com/toursprung/TSMessages.git</string>
+		<key>D48E31BE-405E-43F2-AEE5-E5D5996DE94E</key>
+		<string>https://github.com/Bluezen/TSMessages.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>ExampleProject/Example.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>56C72571-8325-46B6-BC46-920E7DE5B629</key>
+		<key>D48E31BE-405E-43F2-AEE5-E5D5996DE94E</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/toursprung/TSMessages.git</string>
+	<string>https://github.com/Bluezen/TSMessages.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>56C72571-8325-46B6-BC46-920E7DE5B629</string>
+	<string>D48E31BE-405E-43F2-AEE5-E5D5996DE94E</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>56C72571-8325-46B6-BC46-920E7DE5B629</string>
+			<string>D48E31BE-405E-43F2-AEE5-E5D5996DE94E</string>
 			<key>IDESourceControlWCCName</key>
 			<string>TSMessages</string>
 		</dict>

--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -78,7 +78,7 @@ __weak static UIViewController *_defaultViewController;
                                buttonTitle:nil
                             buttonCallback:nil
                                 atPosition:TSMessageNotificationPositionTop
-                       canBeDismissedByUser:YES];
+                      canBeDismissedByUser:YES];
 }
 
 + (void)showNotificationInViewController:(UIViewController *)viewController
@@ -86,7 +86,7 @@ __weak static UIViewController *_defaultViewController;
                                 subtitle:(NSString *)subtitle
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
-                     canBeDismissedByUser:(BOOL)dismissingEnabled
+                    canBeDismissedByUser:(BOOL)dismissingEnabled
 {
     [self showNotificationInViewController:viewController
                                      title:title
@@ -98,7 +98,7 @@ __weak static UIViewController *_defaultViewController;
                                buttonTitle:nil
                             buttonCallback:nil
                                 atPosition:TSMessageNotificationPositionTop
-                       canBeDismissedByUser:dismissingEnabled];
+                      canBeDismissedByUser:dismissingEnabled];
 }
 
 + (void)showNotificationInViewController:(UIViewController *)viewController
@@ -333,6 +333,8 @@ __weak static UIViewController *_defaultViewController;
         fadeOutToPoint = CGPointMake(currentView.center.x,
                                      currentView.viewController.view.bounds.size.height + CGRectGetHeight(currentView.frame)/2.f);
     }
+    
+    [currentView executeCallback];
     
     [UIView animateWithDuration:kTSMessageAnimationDuration animations:^
      {

--- a/TSMessages/Views/TSMessageView.h
+++ b/TSMessages/Views/TSMessageView.h
@@ -76,5 +76,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled;
 /** Use this method to load a custom design file */
 + (void)addNotificationDesignFromFile:(NSString *)file;
 
+/** Perform callback if exists **/
+- (void)executeCallback;
 
 @end

--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -326,12 +326,6 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
                                                                                      action:@selector(fadeMeOut)];
             [self addGestureRecognizer:tapRec];
         }
-        
-        if (self.callback) {
-            UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
-            tapGesture.delegate = self;
-            [self addGestureRecognizer:tapGesture];
-        }
     }
     return self;
 }
@@ -455,6 +449,13 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     [[TSMessage sharedMessage] performSelectorOnMainThread:@selector(fadeOutNotification:) withObject:self waitUntilDone:NO];
 }
 
+- (void)executeCallback
+{
+    if (self.callback) {
+        self.callback();
+    }
+}
+
 - (void)didMoveToWindow {
     [super didMoveToWindow];
     if (self.duration == TSMessageNotificationDurationEndless && self.superview && !self.window ) {
@@ -472,17 +473,6 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     }
     
     [self fadeMeOut];
-}
-
-- (void)handleTap:(UITapGestureRecognizer *)tapGesture
-{
-    if (tapGesture.state == UIGestureRecognizerStateRecognized)
-    {
-        if (self.callback)
-        {
-            self.callback();
-        }
-    }
 }
 
 #pragma mark - UIGestureRecognizerDelegate


### PR DESCRIPTION
At the moment documentation defines the callback like that that: "The block that should be executed, when the user dismissed the message by tapping on it or swiping it to the top".

Unfortunately right now callback is called only after the message view gets touched.

For my own use I prefer that the callback block gets called whenever the message view is dismissed, whatever is the way it has been dismissed. 
Here is my quick proposition of a way to achieve this, not 100% sure if I have done it the best way though (for this purpose it might be a better idea to call the callback directly inside the view before it gets removed from parents...).

This pull request is related to question #139
