### PR TITLE
Fixed CUICatalog: Invalid asset name supplied

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -143,7 +143,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         current = [notificationDesign valueForKey:currentString];
         
         
-        if (!image && [current valueForKey:@"imageName"])
+        if (!image && [[current valueForKey:@"imageName"] length])
         {
             image = [UIImage imageNamed:[current valueForKey:@"imageName"]];
         }


### PR DESCRIPTION
As noted in #155
