### PR TITLE
Fixes #164 a very small visual bug

### DIFF
--- a/TSMessages/Views/TSMessageView.m
+++ b/TSMessages/Views/TSMessageView.m
@@ -372,7 +372,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         // Check if that makes the popup larger (height)
         if (self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height + TSMessageViewPadding > currentHeight)
         {
-            currentHeight = self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height;
+            currentHeight = self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height + TSMessageViewPadding;
         }
         else
         {


### PR DESCRIPTION
If the icon image’s height is taller than the currentHeight
(title+subtitle+padding), a small miscalculation would cut off the image,
it is now fixed!
