### PR TITLE
Fixed iPad modally shown ViewControler offset

### DIFF
--- a/TSMessages/Classes/TSMessage.m
+++ b/TSMessages/Classes/TSMessage.m
@@ -236,6 +236,14 @@ __weak static UIViewController *_defaultViewController;
         }
     }
     
+    if(currentView.viewController.presentingViewController)
+    {
+        //If we show the Message on an modally presented VC we need to adjust for possible y offsets (UIModalPresentationPageSheet etc.)
+        CGFloat yOrigin = [currentView.viewController.presentingViewController.view convertRect:currentView.viewController.view.bounds fromView:currentView.viewController.view].origin.y;
+        
+        verticalOffset -= yOrigin;
+    }
+    
     CGPoint toPoint;
     if (currentView.messagePosition == TSMessageNotificationPositionTop)
     {


### PR DESCRIPTION
I noticed while developing some iPad stuff that if you show a ViewController modally with a modalPresentationStyle of UIModalPresentationPageSheet that the TSMessage View doesn't account for the possible y offset of the VC. I didn't have the time to check the code for other side effects, but everything I tried and tested so far looked the same as before.
