### PR TITLE
Fixed an iOS 8 version check

### DIFF
--- a/Pod/Classes/TSMessage.m
+++ b/Pod/Classes/TSMessage.m
@@ -198,14 +198,7 @@ __weak static UIViewController *_defaultViewController;
         }
         
         CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
-        
-        if ([[UIApplication sharedApplication] respondsToSelector:@selector(registerForRemoteNotifications)]) {
-            verticalOffset += statusBarSize.height;
-        } else {
-            BOOL isPortrait = UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation]);
-            CGFloat offset = isPortrait ? statusBarSize.height : statusBarSize.width;
-            verticalOffset += offset;
-        }
+        verticalOffset += MIN(statusBarSize.width, statusBarSize.height);
     };
     
     if ([currentView.viewController isKindOfClass:[UINavigationController class]] || [currentView.viewController.parentViewController isKindOfClass:[UINavigationController class]])


### PR DESCRIPTION
Testing if UIApplication responds to registerForRemoteNotifications is a really ugly way to check if we're running on iOS 8, when the code has nothing to do with remote notifications.

Just get the minimum dimension since a status bar will always be wider than it is tall.
