### PR TITLE
Fixes NSBundle issues with Swift / Cocoapods v0.36.0beta1

### DIFF
--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -63,7 +63,7 @@ static NSMutableDictionary *_notificationDesign;
 {
     if (!_notificationDesign)
     {
-        NSString *path = [[NSBundle mainBundle] pathForResource:TSDesignFileName ofType:@"json"];
+        NSString *path = [[NSBundle bundleForClass:self.class] pathForResource:TSDesignFileName ofType:@"json"];
         NSData *data = [NSData dataWithContentsOfFile:path];
         NSAssert(data != nil, @"Could not read TSMessages config file from main bundle with name %@.json", TSDesignFileName);
         


### PR DESCRIPTION
I had an issue when using TSMessages using Swift and Cocoapods 0.36.0.beta1 because of the bundle not being found.