### PR TITLE
Fixed crash in Example project on iPad

### DIFF
--- a/Example/TSMessages/TSMessages-Info.plist
+++ b/Example/TSMessages/TSMessages-Info.plist
@@ -27,7 +27,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>
-	<string>Main_iPad</string>
+	<string>Main_iPhone</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Changed iPad storyboard to Main_iPhone, fixing crash: «Could not find a
storyboard named 'Main_iPad’».