### PR TITLE
HexColors legacy Fix with podspecs

### DIFF
--- a/TSMessages.podspec
+++ b/TSMessages.podspec
@@ -9,15 +9,15 @@
 
 Pod::Spec.new do |s|
   s.name             = "TSMessages"
-  s.version          = "0.9.12"
+  s.version          = "0.9.13"
   s.summary          = "Easy to use and customizable messages/notifications for iOS à la Tweetbot."
   s.description  = <<-DESC
-                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). 
+                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot).
 The notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.
 There are 4 different types already set up for you: Success, Error, Warning, Message.
                    DESC
   s.homepage     = "https://github.com/KrauseFx/TSMessages/"
-  
+
   s.license          = 'MIT'
   s.author           = { "Felix Krause" => "krausefx@gmail.com" }
   s.source           = { :git => "https://github.com/KrauseFx/TSMessages.git", :tag => s.version.to_s }
@@ -30,5 +30,5 @@ There are 4 different types already set up for you: Success, Error, Warning, Mes
   s.resources = ['Pod/Assets/*.png', 'Pod/Assets/*.json']
 
   s.public_header_files = 'Pod/Classes/**/*.h'
-  s.dependency 'HexColors'
+  s.dependency 'HexColors', '~> 2.3.0'
 end

--- a/podspecs/0.9.1/TSMessages.podspec.json
+++ b/podspecs/0.9.1/TSMessages.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.1",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "felix@toursprung.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.1"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "Classes/**/*.{h,m}",
+    "Views/**/*.{h,m}"
+  ],
+  "resources": "Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "MLUIColorAdditions": [
+
+    ]
+  }
+}

--- a/podspecs/0.9.10/TSMessages.podspec.json
+++ b/podspecs/0.9.10/TSMessages.podspec.json
@@ -1,0 +1,31 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.10",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.10"
+  },
+  "social_media_url": "https://twitter.com/KrauseFx",
+  "platforms": {
+    "ios": "5.0"
+  },
+  "requires_arc": true,
+  "source_files": "Pod/Classes",
+  "resources": [
+    "Pod/Assets/*.png",
+    "Pod/Assets/*.json"
+  ],
+  "public_header_files": "Pod/Classes/**/*.h",
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.11/TSMessages.podspec.json
+++ b/podspecs/0.9.11/TSMessages.podspec.json
@@ -1,0 +1,31 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.11",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.11"
+  },
+  "social_media_url": "https://twitter.com/KrauseFx",
+  "platforms": {
+    "ios": "5.0"
+  },
+  "requires_arc": true,
+  "source_files": "Pod/Classes",
+  "resources": [
+    "Pod/Assets/*.png",
+    "Pod/Assets/*.json"
+  ],
+  "public_header_files": "Pod/Classes/**/*.h",
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.12/TSMessages.podspec.json
+++ b/podspecs/0.9.12/TSMessages.podspec.json
@@ -1,0 +1,31 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.12",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/KrauseFx/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/KrauseFx/TSMessages.git",
+    "tag": "0.9.12"
+  },
+  "social_media_url": "https://twitter.com/KrauseFx",
+  "platforms": {
+    "ios": "5.0"
+  },
+  "requires_arc": true,
+  "source_files": "Pod/Classes",
+  "resources": [
+    "Pod/Assets/*.png",
+    "Pod/Assets/*.json"
+  ],
+  "public_header_files": "Pod/Classes/**/*.h",
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.2/TSMessages.podspec.json
+++ b/podspecs/0.9.2/TSMessages.podspec.json
@@ -1,0 +1,24 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.2",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "felix@toursprung.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.2"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "Classes/**/*.{h,m}",
+    "Views/**/*.{h,m}"
+  ],
+  "resources": "Resources/**/*.{png,json}",
+  "requires_arc": true
+}

--- a/podspecs/0.9.3/TSMessages.podspec.json
+++ b/podspecs/0.9.3/TSMessages.podspec.json
@@ -1,0 +1,24 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.3",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "felix@toursprung.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.3"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "Classes/**/*.{h,m}",
+    "Views/**/*.{h,m}"
+  ],
+  "resources": "Resources/**/*.{png,json}",
+  "requires_arc": true
+}

--- a/podspecs/0.9.4/TSMessages.podspec.json
+++ b/podspecs/0.9.4/TSMessages.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.4",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.4"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "TSMessages/Classes/**/*.{h,m}",
+    "TSMessages/Views/**/*.{h,m}"
+  ],
+  "resources": "TSMessages/Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.5/TSMessages.podspec.json
+++ b/podspecs/0.9.5/TSMessages.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.5",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "social_media_url": "https://twitter.com/KrauseFx",
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.5"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "TSMessages/Classes/**/*.{h,m}",
+    "TSMessages/Views/**/*.{h,m}"
+  ],
+  "resources": "TSMessages/Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.6/TSMessages.podspec.json
+++ b/podspecs/0.9.6/TSMessages.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.6",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.6"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "TSMessages/Classes/**/*.{h,m}",
+    "TSMessages/Views/**/*.{h,m}"
+  ],
+  "resources": "TSMessages/Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.7/TSMessages.podspec.json
+++ b/podspecs/0.9.7/TSMessages.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.7",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "social_media_url": "https://twitter.com/KrauseFx",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.7"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "TSMessages/Classes/**/*.{h,m}",
+    "TSMessages/Views/**/*.{h,m}"
+  ],
+  "resources": "TSMessages/Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.8/TSMessages.podspec.json
+++ b/podspecs/0.9.8/TSMessages.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.8",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.8"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "TSMessages/Classes/**/*.{h,m}",
+    "TSMessages/Views/**/*.{h,m}"
+  ],
+  "resources": "TSMessages/Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9.9/TSMessages.podspec.json
+++ b/podspecs/0.9.9/TSMessages.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TSMessages",
+  "version": "0.9.9",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "krausefx@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9.9"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "TSMessages/Classes/**/*.{h,m}",
+    "TSMessages/Views/**/*.{h,m}"
+  ],
+  "resources": "TSMessages/Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "HexColors": [
+        "~> 2.2.0"
+    ]
+  }
+}

--- a/podspecs/0.9/TSMessages.podspec.json
+++ b/podspecs/0.9/TSMessages.podspec.json
@@ -1,0 +1,29 @@
+{
+  "name": "TSMessages",
+  "version": "0.9",
+  "summary": "Easy to use and customizable messages/notifications for iOS à la Tweetbot.",
+  "description": "                    This framework provides an easy to use class to show little notification views on the top of the screen. (à la Tweetbot). \nThe notification moves from the top of the screen underneath the navigation bar and stays there for a few seconds, depending on the length of the displayed text. To dismiss a notification before the time runs out, the user can swipe it to the top or just tap it.\nThere are 4 different types already set up for you: Success, Error, Warning, Message.\n",
+  "homepage": "https://github.com/toursprung/TSMessages/",
+  "license": "MIT",
+  "authors": {
+    "Felix Krause": "felix@toursprung.com"
+  },
+  "source": {
+    "git": "https://github.com/toursprung/TSMessages.git",
+    "tag": "0.9"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "Classes/**/*.{h,m}",
+    "Views/**/*.{h,m}"
+  ],
+  "resources": "Resources/**/*.{png,json}",
+  "requires_arc": true,
+  "dependencies": {
+    "MLUIColorAdditions": [
+
+    ]
+  }
+}


### PR DESCRIPTION
* changed the submodule to use the current release of HexColors
* updated the current podspec to bump the version to 0.9.13 to fix the current situation of TSMessages
 * @KrauseFx you need to tag the merge request with 0.9.13 after the pull request to make this working
* I added all the old podspec files to make it easy as possible to update the current situation on cocoapods and the old version should working fine again. 
  * @KrauseFx you need to update the podspecs on cocoapods then. Sorry for this :bow: 