### PR TITLE
Replace code deprecated in iOS7

### DIFF
--- a/Example/TSMessages/TSDemoViewController.m
+++ b/Example/TSMessages/TSDemoViewController.m
@@ -19,8 +19,38 @@
     
     [TSMessage setDefaultViewController:self];
     [TSMessage setDelegate:self];
-    self.wantsFullScreenLayout = YES;
+    [self setFullscreenLayout:YES];
+    
     [self.navigationController.navigationBar setTranslucent:YES];
+}
+
+- (void)setFullscreenLayout:(bool)wantsFullscreen {
+    if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
+        if (wantsFullscreen) {
+            self.edgesForExtendedLayout = UIRectEdgeAll;
+        }
+        else {
+            self.edgesForExtendedLayout = UIRectEdgeNone;
+        }
+    }
+    else {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        self.wantsFullScreenLayout = wantsFullscreen;
+        #pragma clang diagnostic pop
+    }
+}
+
+- (bool)isFullscreen {
+    if ([self respondsToSelector:@selector(edgesForExtendedLayout)] && self.edgesForExtendedLayout == UIRectEdgeAll) {
+        return YES;
+    }
+    else {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return self.wantsFullScreenLayout;
+        #pragma clang diagnostic pop
+    }
 }
 
 - (IBAction)didTapError:(id)sender
@@ -82,7 +112,7 @@
 
 - (IBAction)didTapToggleWantsFullscreen:(id)sender
 {
-    self.wantsFullScreenLayout = !self.wantsFullScreenLayout;
+    [self setFullscreenLayout:![self isFullscreen]];
     [self.navigationController.navigationBar setTranslucent:!self.navigationController.navigationBar.isTranslucent];
 }
 

--- a/TSMessages.podspec
+++ b/TSMessages.podspec
@@ -23,7 +23,7 @@ There are 4 different types already set up for you: Success, Error, Warning, Mes
   s.source           = { :git => "https://github.com/KrauseFx/TSMessages.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/KrauseFx'
 
-  s.platform     = :ios, '5.0'
+  s.platform     = :ios, '7.0'
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes'


### PR DESCRIPTION
Replace wantsFullScreenLayout with iOS7+ supported methods. Wrap <=iOS7 code into an else block with deprecation warning suppression. 

Sorry about the whitespace - seems something happened there between the edits!
