### PR TITLE
Loading custom icon images from the Images.xcasset 

### DIFF
--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -246,6 +246,10 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         {
             image = [self bundledImageNamed:[current valueForKey:@"imageName"]];
         }
+        if (!image && [[current valueForKey:@"imageName"] length])
+        {
+            image = [UIImage imageNamed:[current valueForKey:@"imageName"]];
+        }
 
         if (![TSMessage iOS7StyleEnabled])
         {


### PR DESCRIPTION
When the alternative design file is proviced , the custom image icon is loaded from the app bundle . I made small change for loading files from the Images assets when the image isn't available in the app bundle.